### PR TITLE
tweak internal macro syntax to compile on stable

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -118,27 +118,27 @@ macro_rules! approx_dmin_to_dmax_no_nan {
 }
 
 macro_rules! num_conv {
-    (@ $src:ty; $(,)*) => {};
+    (@ $src:ty=> $(,)*) => {};
 
-    (@ $src:ty; #[32] $($tail:tt)*) => {
-        num_conv! { @ $src; (#[cfg(target_pointer_width="32")]) $($tail)* }
+    (@ $src:ty=> #[32] $($tail:tt)*) => {
+        num_conv! { @ $src=> (#[cfg(target_pointer_width="32")]) $($tail)* }
     };
 
-    (@ $src:ty; #[64] $($tail:tt)*) => {
-        num_conv! { @ $src; (#[cfg(target_pointer_width="64")]) $($tail)* }
+    (@ $src:ty=> #[64] $($tail:tt)*) => {
+        num_conv! { @ $src=> (#[cfg(target_pointer_width="64")]) $($tail)* }
     };
 
-    (@ $src:ty; e   $($tail:tt)*) => { num_conv! { @ $src; () e   $($tail)* } };
-    (@ $src:ty; n+  $($tail:tt)*) => { num_conv! { @ $src; () n+  $($tail)* } };
-    (@ $src:ty; n   $($tail:tt)*) => { num_conv! { @ $src; () n   $($tail)* } };
-    (@ $src:ty; w+  $($tail:tt)*) => { num_conv! { @ $src; () w+  $($tail)* } };
-    (@ $src:ty; w   $($tail:tt)*) => { num_conv! { @ $src; () w   $($tail)* } };
-    (@ $src:ty; aW  $($tail:tt)*) => { num_conv! { @ $src; () aW  $($tail)* } };
-    (@ $src:ty; nf  $($tail:tt)*) => { num_conv! { @ $src; () nf  $($tail)* } };
-    (@ $src:ty; fan $($tail:tt)*) => { num_conv! { @ $src; () fan $($tail)* } };
+    (@ $src:ty=> e   $($tail:tt)*) => { num_conv! { @ $src=> () e   $($tail)* } };
+    (@ $src:ty=> n+  $($tail:tt)*) => { num_conv! { @ $src=> () n+  $($tail)* } };
+    (@ $src:ty=> n   $($tail:tt)*) => { num_conv! { @ $src=> () n   $($tail)* } };
+    (@ $src:ty=> w+  $($tail:tt)*) => { num_conv! { @ $src=> () w+  $($tail)* } };
+    (@ $src:ty=> w   $($tail:tt)*) => { num_conv! { @ $src=> () w   $($tail)* } };
+    (@ $src:ty=> aW  $($tail:tt)*) => { num_conv! { @ $src=> () aW  $($tail)* } };
+    (@ $src:ty=> nf  $($tail:tt)*) => { num_conv! { @ $src=> () nf  $($tail)* } };
+    (@ $src:ty=> fan $($tail:tt)*) => { num_conv! { @ $src=> () fan $($tail)* } };
 
     // Exact conversion
-    (@ $src:ty; ($($attrs:tt)*) e $dst:ty, $($tail:tt)*) => {
+    (@ $src:ty=> ($($attrs:tt)*) e $dst:ty, $($tail:tt)*) => {
         as_item! {
             approx_blind! { ($($attrs)*), $src, $dst, ::DefaultApprox }
             approx_blind! { ($($attrs)*), $src, $dst, ::Wrapping }
@@ -151,11 +151,11 @@ macro_rules! num_conv {
                 }
             }
         }
-        num_conv! { @ $src; $($tail)* }
+        num_conv! { @ $src=> $($tail)* }
     };
 
     // Narrowing a signed type *into* an unsigned type where the destination type's maximum value is representable by the source type.
-    (@ $src:ty; ($($attrs:tt)*) n+ $dst:ident, $($tail:tt)*) => {
+    (@ $src:ty=> ($($attrs:tt)*) n+ $dst:ident, $($tail:tt)*) => {
         as_item! {
             approx_z_to_dmax! { ($($attrs)*), $src, $dst, ::DefaultApprox }
             approx_blind! { ($($attrs)*), $src, $dst, ::Wrapping }
@@ -174,11 +174,11 @@ macro_rules! num_conv {
                 }
             }
         }
-        num_conv! { @ $src; $($tail)* }
+        num_conv! { @ $src=> $($tail)* }
     };
 
     // Narrowing an unsigned type *into* a type where the destination type's maximum value is representable by the source type.
-    (@ $src:ty; ($($attrs:tt)*) n- $dst:ident, $($tail:tt)*) => {
+    (@ $src:ty=> ($($attrs:tt)*) n- $dst:ident, $($tail:tt)*) => {
         as_item! {
             approx_to_dmax! { ($($attrs)*), $src, $dst, ::DefaultApprox }
             approx_blind! { ($($attrs)*), $src, $dst, ::Wrapping }
@@ -194,11 +194,11 @@ macro_rules! num_conv {
                 }
             }
         }
-        num_conv! { @ $src; $($tail)* }
+        num_conv! { @ $src=> $($tail)* }
     };
 
     // Narrowing where the destination type's bounds are representable by the source type.
-    (@ $src:ty; ($($attrs:tt)*) n $dst:ident, $($tail:tt)*) => {
+    (@ $src:ty=> ($($attrs:tt)*) n $dst:ident, $($tail:tt)*) => {
         as_item! {
             approx_dmin_to_dmax! { ($($attrs)*), $src, $dst, ::DefaultApprox }
             approx_blind! { ($($attrs)*), $src, $dst, ::Wrapping }
@@ -217,11 +217,11 @@ macro_rules! num_conv {
                 }
             }
         }
-        num_conv! { @ $src; $($tail)* }
+        num_conv! { @ $src=> $($tail)* }
     };
 
     // Widening a signed type *into* an unsigned type.
-    (@ $src:ty; ($($attrs:tt)*) w+ $dst:ident, $($tail:tt)*) => {
+    (@ $src:ty=> ($($attrs:tt)*) w+ $dst:ident, $($tail:tt)*) => {
         as_item! {
             approx_z_up! { ($($attrs)*), $src, $dst, ::DefaultApprox }
             approx_blind! { ($($attrs)*), $src, $dst, ::Wrapping }
@@ -237,11 +237,11 @@ macro_rules! num_conv {
                 }
             }
         }
-        num_conv! { @ $src; $($tail)* }
+        num_conv! { @ $src=> $($tail)* }
     };
 
     // Widening.
-    (@ $src:ty; ($($attrs:tt)*) w $dst:ident, $($tail:tt)*) => {
+    (@ $src:ty=> ($($attrs:tt)*) w $dst:ident, $($tail:tt)*) => {
         as_item! {
             approx_blind! { ($($attrs)*), $src, $dst, ::DefaultApprox }
             approx_blind! { ($($attrs)*), $src, $dst, ::Wrapping }
@@ -254,11 +254,11 @@ macro_rules! num_conv {
                 }
             }
         }
-        num_conv! { @ $src; $($tail)* }
+        num_conv! { @ $src=> $($tail)* }
     };
 
     // Narrowing *into* a floating-point type where the conversion is only exact within a given range.
-    (@ $src:ty; ($($attrs:tt)*) nf [+- $bound:expr] $dst:ident, $($tail:tt)*) => {
+    (@ $src:ty=> ($($attrs:tt)*) nf [+- $bound:expr] $dst:ident, $($tail:tt)*) => {
         as_item! {
             approx_blind! { ($($attrs)*), $src, $dst, ::DefaultApprox }
 
@@ -276,10 +276,10 @@ macro_rules! num_conv {
                 }
             }
         }
-        num_conv! { @ $src; $($tail)* }
+        num_conv! { @ $src=> $($tail)* }
     };
 
-    (@ $src:ty; ($($attrs:tt)*) nf [, $max:expr] $dst:ident, $($tail:tt)*) => {
+    (@ $src:ty=> ($($attrs:tt)*) nf [, $max:expr] $dst:ident, $($tail:tt)*) => {
         as_item! {
             approx_blind! { ($($attrs)*), $src, $dst, ::DefaultApprox }
 
@@ -294,44 +294,44 @@ macro_rules! num_conv {
                 }
             }
         }
-        num_conv! { @ $src; $($tail)* }
+        num_conv! { @ $src=> $($tail)* }
     };
 
     // Approximately narrowing a floating point value *into* a type where the source value is constrained by the given range of values.
-    (@ $src:ty; ($($attrs:tt)*) fan $dst:ident, $($tail:tt)*) => {
+    (@ $src:ty=> ($($attrs:tt)*) fan $dst:ident, $($tail:tt)*) => {
         as_item! {
             approx_dmin_to_dmax_no_nan! { ($($attrs)*), $src, $dst, ::DefaultApprox }
         }
-        num_conv! { @ $src; $($tail)* }
+        num_conv! { @ $src=> $($tail)* }
     };
 
-    ($src:ty; $($tail:tt)*) => {
-        num_conv! { @ $src; $($tail)*, }
+    ($src:ty=> $($tail:tt)*) => {
+        num_conv! { @ $src=> $($tail)*, }
     };
 }
 
 mod lang_ints {
-    num_conv! { i8;  w i16, w i32, w i64, w+u8, w+u16, w+u32, w+u64, w isize, w+usize }
-    num_conv! { i16; n i8, w i32, w i64, n+u8, w+u16, w+u32, w+u64, w isize, w+usize }
-    num_conv! { i32; n i8, n i16, w i64, n+u8, n+u16, w+u32, w+u64 }
-    num_conv! { i64; n i8, n i16, n i32, n+u8, n+u16, n+u32, w+u64 }
-    num_conv! { i32; #[32] e isize, #[64] w isize, w+usize }
-    num_conv! { i64; #[32] n isize, #[64] e isize, n+usize }
+    num_conv! { i8=>  w i16, w i32, w i64, w+u8, w+u16, w+u32, w+u64, w isize, w+usize }
+    num_conv! { i16=> n i8, w i32, w i64, n+u8, w+u16, w+u32, w+u64, w isize, w+usize }
+    num_conv! { i32=> n i8, n i16, w i64, n+u8, n+u16, w+u32, w+u64 }
+    num_conv! { i64=> n i8, n i16, n i32, n+u8, n+u16, n+u32, w+u64 }
+    num_conv! { i32=> #[32] e isize, #[64] w isize, w+usize }
+    num_conv! { i64=> #[32] n isize, #[64] e isize, n+usize }
 
-    num_conv! { u8; n-i8, w i16, w i32, w i64, w u16, w u32, w u64, w isize, w usize }
-    num_conv! { u16; n-i8, n-i16, w i32, w i64, n-u8, w u32, w u64, w isize, w usize }
-    num_conv! { u32; n-i8, n-i16, n-i32, w i64, n-u8, n-u16, w u64 }
-    num_conv! { u64; n-i8, n-i16, n-i32, n-i64, n-u8, n-u16, n-u32 }
-    num_conv! { u32; #[32] n-isize, #[64] w isize, #[32] e usize, #[64] w usize }
-    num_conv! { u64; n-isize, #[32] n-usize, #[64] e usize }
+    num_conv! { u8=> n-i8, w i16, w i32, w i64, w u16, w u32, w u64, w isize, w usize }
+    num_conv! { u16=> n-i8, n-i16, w i32, w i64, n-u8, w u32, w u64, w isize, w usize }
+    num_conv! { u32=> n-i8, n-i16, n-i32, w i64, n-u8, n-u16, w u64 }
+    num_conv! { u64=> n-i8, n-i16, n-i32, n-i64, n-u8, n-u16, n-u32 }
+    num_conv! { u32=> #[32] n-isize, #[64] w isize, #[32] e usize, #[64] w usize }
+    num_conv! { u64=> n-isize, #[32] n-usize, #[64] e usize }
 
-    num_conv! { isize; n i8, n i16, #[32] e i32, #[32] w i64, #[64] n i32, #[64] e i64 }
-    num_conv! { isize; n+u8, n+u16, #[32] w+u32, #[32] w+u64, #[64] n+u32, #[64] w+u64 }
-    num_conv! { isize; w+usize }
+    num_conv! { isize=> n i8, n i16, #[32] e i32, #[32] w i64, #[64] n i32, #[64] e i64 }
+    num_conv! { isize=> n+u8, n+u16, #[32] w+u32, #[32] w+u64, #[64] n+u32, #[64] w+u64 }
+    num_conv! { isize=> w+usize }
 
-    num_conv! { usize; n-i8, n-i16, #[32] n-i32, #[32] w i64, #[64] n-i32, #[64] n-i64 }
-    num_conv! { usize; n-u8, n-u16, #[32] e u32, #[32] w u64, #[64] n-u32, #[64] e u64 }
-    num_conv! { usize; n-isize }
+    num_conv! { usize=> n-i8, n-i16, #[32] n-i32, #[32] w i64, #[64] n-i32, #[64] n-i64 }
+    num_conv! { usize=> n-u8, n-u16, #[32] e u32, #[32] w u64, #[64] n-u32, #[64] e u64 }
+    num_conv! { usize=> n-isize }
 }
 
 mod lang_floats {
@@ -374,23 +374,23 @@ mod lang_floats {
 }
 
 mod lang_int_to_float {
-    num_conv! { i8;  w f32, w f64 }
-    num_conv! { i16; w f32, w f64 }
-    num_conv! { i32; nf [+- 16_777_216] f32, w f64 }
-    num_conv! { i64; nf [+- 16_777_216] f32, nf [+- 9_007_199_254_740_992] f64 }
+    num_conv! { i8=>  w f32, w f64 }
+    num_conv! { i16=> w f32, w f64 }
+    num_conv! { i32=> nf [+- 16_777_216] f32, w f64 }
+    num_conv! { i64=> nf [+- 16_777_216] f32, nf [+- 9_007_199_254_740_992] f64 }
 
-    num_conv! { u8;  w f32, w f64 }
-    num_conv! { u16; w f32, w f64 }
-    num_conv! { u32; nf [, 16_777_216] f32, w f64 }
-    num_conv! { u64; nf [, 16_777_216] f32, nf [, 9_007_199_254_740_992] f64 }
+    num_conv! { u8=>  w f32, w f64 }
+    num_conv! { u16=> w f32, w f64 }
+    num_conv! { u32=> nf [, 16_777_216] f32, w f64 }
+    num_conv! { u64=> nf [, 16_777_216] f32, nf [, 9_007_199_254_740_992] f64 }
 }
 
 mod lang_float_to_int {
-    num_conv! { f32; fan i8, fan i16, fan i32, fan i64 }
-    num_conv! { f32; fan u8, fan u16, fan u32, fan u64 }
-    num_conv! { f32; fan isize, fan usize }
+    num_conv! { f32=> fan i8, fan i16, fan i32, fan i64 }
+    num_conv! { f32=> fan u8, fan u16, fan u32, fan u64 }
+    num_conv! { f32=> fan isize, fan usize }
 
-    num_conv! { f64; fan i8, fan i16, fan i32, fan i64 }
-    num_conv! { f64; fan u8, fan u16, fan u32, fan u64 }
-    num_conv! { f64; fan isize, fan usize }
+    num_conv! { f64=> fan i8, fan i16, fan i32, fan i64 }
+    num_conv! { f64=> fan u8, fan u16, fan u32, fan u64 }
+    num_conv! { f64=> fan isize, fan usize }
 }

--- a/tests/lang_floats.rs
+++ b/tests/lang_floats.rs
@@ -9,36 +9,36 @@ use conv::FloatError::Overflow as FO;
 
 #[test]
 fn test_f32() {
-    check!(f32, f32; fident; qv: *;);
-    check!(f32, f64; fident; qv: *;);
+    check!(f32, f32=> fident; qv: *;);
+    check!(f32, f64=> fident; qv: *;);
 }
 
 #[test]
 fn test_f32_to_int() {
-    check!(f32, i8;  sidenta; qa: i8;  a: -129.0, !FU; a: 128.0, !FO;);
-    check!(f32, i16; sidenta; qa: i16; a: -32_769.0, !FU; a: 32_768.0, !FO;);
-    check!(f32, i32; sidenta; qa: i32; a: -2_147_500_000.0, !FU; a: 2_147_500_000.0, !FO;);
-    check!(f32, i64; sidenta; qa: i64; a: -9_223_373_000_000_000_000.0, !FU; a: 9_223_373_000_000_000_000.0, !FO;);
-    check!(f32, u8;  uidenta; qa: u8;  a: -1.0, !FU; a: 256.0, !FO;);
-    check!(f32, u16; uidenta; qa: u16; a: -1.0, !FU; a: 65_536.0, !FO;);
-    check!(f32, u32; uidenta; qa: u32; a: -1.0, !FU; a: 4_294_968_000.0, !FO;);
-    check!(f32, u64; uidenta; qa: u64; a: -1.0, !FU; a: 18_446_746_000_000_000_000.0, !FO;);
+    check!(f32, i8=>  sidenta; qa: i8=>  a: -129.0, !FU; a: 128.0, !FO;);
+    check!(f32, i16=> sidenta; qa: i16=> a: -32_769.0, !FU; a: 32_768.0, !FO;);
+    check!(f32, i32=> sidenta; qa: i32=> a: -2_147_500_000.0, !FU; a: 2_147_500_000.0, !FO;);
+    check!(f32, i64=> sidenta; qa: i64=> a: -9_223_373_000_000_000_000.0, !FU; a: 9_223_373_000_000_000_000.0, !FO;);
+    check!(f32, u8=>  uidenta; qa: u8=>  a: -1.0, !FU; a: 256.0, !FO;);
+    check!(f32, u16=> uidenta; qa: u16=> a: -1.0, !FU; a: 65_536.0, !FO;);
+    check!(f32, u32=> uidenta; qa: u32=> a: -1.0, !FU; a: 4_294_968_000.0, !FO;);
+    check!(f32, u64=> uidenta; qa: u64=> a: -1.0, !FU; a: 18_446_746_000_000_000_000.0, !FO;);
 }
 
 #[test]
 fn test_f64_to_int() {
-    check!(f64, i8;  sidenta; qa: i8;  a: -129.0, !FU; a: 128.0, !FO;);
-    check!(f64, i16; sidenta; qa: i16; a: -32_769.0, !FU; a: 32_768.0, !FO;);
-    check!(f64, i32; sidenta; qa: i32; a: -2_147_483_649.0, !FU; a: 2_147_483_648.0, !FO;);
-    check!(f64, i64; sidenta; qa: i64; a: -9_223_372_036_854_778_000.0, !FU; a: 9_223_372_036_854_778_000.0, !FO;);
-    check!(f64, u8;  uidenta; qa: u8;  a: -1.0, !FU; a: 256.0, !FO;);
-    check!(f64, u16; uidenta; qa: u16; a: -1.0, !FU; a: 65_536.0, !FO;);
-    check!(f64, u32; uidenta; qa: u32; a: -1.0, !FU; a: 4_294_967_296.0, !FO;);
-    check!(f64, u64; uidenta; qa: u64; a: -1.0, !FU; a: 18_446_744_073_709_560_000.0, !FO;);
+    check!(f64, i8=>  sidenta; qa: i8=>  a: -129.0, !FU; a: 128.0, !FO;);
+    check!(f64, i16=> sidenta; qa: i16=> a: -32_769.0, !FU; a: 32_768.0, !FO;);
+    check!(f64, i32=> sidenta; qa: i32=> a: -2_147_483_649.0, !FU; a: 2_147_483_648.0, !FO;);
+    check!(f64, i64=> sidenta; qa: i64=> a: -9_223_372_036_854_778_000.0, !FU; a: 9_223_372_036_854_778_000.0, !FO;);
+    check!(f64, u8=>  uidenta; qa: u8=>  a: -1.0, !FU; a: 256.0, !FO;);
+    check!(f64, u16=> uidenta; qa: u16=> a: -1.0, !FU; a: 65_536.0, !FO;);
+    check!(f64, u32=> uidenta; qa: u32=> a: -1.0, !FU; a: 4_294_967_296.0, !FO;);
+    check!(f64, u64=> uidenta; qa: u64=> a: -1.0, !FU; a: 18_446_744_073_709_560_000.0, !FO;);
 }
 
 #[test]
 fn test_f64() {
-    check!(f64, f32; fidenta; qa: *;);
-    check!(f64, f64; fident; qv: *;);
+    check!(f64, f32=> fidenta; qa: *;);
+    check!(f64, f64=> fident; qv: *;);
 }

--- a/tests/lang_ints.rs
+++ b/tests/lang_ints.rs
@@ -11,80 +11,80 @@ use conv::RangeError::Overflow as RO;
 
 #[test]
 fn test_i8() {
-    check!(i8, i8; sident; qv: *; qa: *; qaW: *);
-    check!(i8, i16; sident; qv: *; qa: *; qaW: *);
-    check!(i8, i32; sident; qv: *; qa: *; qaW: *);
-    check!(i8, i64; sident; qv: *; qa: *; qaW: *);
-    check!(i8, u8; uident; qv: +; qa: +; qaW: *;
+    check!(i8, i8=> sident; qv: *; qa: *; qaW: *);
+    check!(i8, i16=> sident; qv: *; qa: *; qaW: *);
+    check!(i8, i32=> sident; qv: *; qa: *; qaW: *);
+    check!(i8, i64=> sident; qv: *; qa: *; qaW: *);
+    check!(i8, u8=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
-    check!(i8, u16; uident; qv: +; qa: +; qaW: *;
+    check!(i8, u16=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
-    check!(i8, u32; uident; qv: +; qa: +; qaW: *;
+    check!(i8, u32=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
-    check!(i8, u64; uident; qv: +; qa: +; qaW: *;
+    check!(i8, u64=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
-    check!(i8, isize; sident; qv: *; qa: *; qaW: *);
-    check!(i8, usize; uident; qv: +; qa: +; qaW: *;
+    check!(i8, isize=> sident; qv: *; qa: *; qaW: *);
+    check!(i8, usize=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
 }
 
 #[test]
 fn test_i16() {
-    check!(i16, i8; sident; qv: i8; qa: i8; qaW: *;
+    check!(i16, i8=> sident; qv: i8=> qa: i8=> qaW: *;
         v: -129, !RU; v: 128, !RO;
     );
-    check!(i16, i16; sident; qv: *; qa: *; qaW: *);
-    check!(i16, i32; sident; qv: *; qa: *; qaW: *);
-    check!(i16, i64; sident; qv: *; qa: *; qaW: *);
-    check!(i16, u8; uident; qv: u8; qa: +; qaW: *;
+    check!(i16, i16=> sident; qv: *; qa: *; qaW: *);
+    check!(i16, i32=> sident; qv: *; qa: *; qaW: *);
+    check!(i16, i64=> sident; qv: *; qa: *; qaW: *);
+    check!(i16, u8=> uident; qv: u8=> qa: +; qaW: *;
         v: -1, !RU;
     );
-    check!(i16, u16; uident; qv: u16, i16; qa: +; qaW: *;
+    check!(i16, u16=> uident; qv: u16, i16=> qa: +; qaW: *;
         v: -1, !Uf;
     );
-    check!(i16, u32; uident; qv: +; qa: +; qaW: *;
+    check!(i16, u32=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
-    check!(i16, u64; uident; qv: +; qa: +; qaW: *;
+    check!(i16, u64=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
-    check!(i16, isize; sident; qv: *; qa: *; qaW: *);
-    check!(i16, usize; uident; qv: +; qa: +; qaW: *;
+    check!(i16, isize=> sident; qv: *; qa: *; qaW: *);
+    check!(i16, usize=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
 }
 
 #[test]
 fn test_i32() {
-    check!(i32, i8; sident; qv: i8; qa: i8; qaW: *;
+    check!(i32, i8=> sident; qv: i8=> qa: i8=> qaW: *;
         v: -129, !RU; v: 128, !RO;
     );
-    check!(i32, i16; sident; qv: i16; qa: i16; qaW: *;
+    check!(i32, i16=> sident; qv: i16=> qa: i16=> qaW: *;
         v: -32_769, !RU; v: 32_768, !RO;
     );
-    check!(i32, i32; sident; qv: *; qa: *; qaW: *);
-    check!(i32, i64; sident; qv: *; qa: *; qaW: *);
-    check!(i32, u8; uident; qv: u8; qa: u8; qaW: *;
+    check!(i32, i32=> sident; qv: *; qa: *; qaW: *);
+    check!(i32, i64=> sident; qv: *; qa: *; qaW: *);
+    check!(i32, u8=> uident; qv: u8=> qa: u8=> qaW: *;
         v: -1, !RU;
     );
-    check!(i32, u16; uident; qv: u16; qa: u16; qaW: *;
+    check!(i32, u16=> uident; qv: u16=> qa: u16=> qaW: *;
         v: -1, !RU;
     );
-    check!(i32, u32; uident; qv: +; qa: +; qaW: *;
+    check!(i32, u32=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
-    check!(i32, u64; uident; qv: +; qa: +; qaW: *;
+    check!(i32, u64=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
     for_bitness! {
         32 {
-            check!(i32, isize; sident; qv: *; qa: *; qaW: *);
-            check!(i32, usize; uident; qv: +; qa: +; qaW: *;
+            check!(i32, isize=> sident; qv: *; qa: *; qaW: *);
+            check!(i32, usize=> uident; qv: +; qa: +; qaW: *;
                 v: -1, !Uf;
             );
         }
@@ -96,35 +96,35 @@ fn test_i32() {
 
 #[test]
 fn test_i64() {
-    check!(i64, i8; sident; qv: i8; qa: i8; qaW: *;
+    check!(i64, i8=> sident; qv: i8=> qa: i8=> qaW: *;
         v: -129, !RU; v: 128, !RO;
     );
-    check!(i64, i16; sident; qv: i16; qa: i16; qaW: *;
+    check!(i64, i16=> sident; qv: i16=> qa: i16=> qaW: *;
         v: -32_769, !RU; v: 32_768, !RO;
     );
-    check!(i64, i32; sident; qv: i32; qa: i32; qaW: *;
+    check!(i64, i32=> sident; qv: i32=> qa: i32=> qaW: *;
         v: -2_147_483_649, !RU; v: 2_147_483_648, !RO;
     );
-    check!(i64, i64; sident; qv: *; qa: *; qaW: *;
+    check!(i64, i64=> sident; qv: *; qa: *; qaW: *;
     );
-    check!(i64, u8; uident; qv: u8; qa: u8; qaW: *;
+    check!(i64, u8=> uident; qv: u8=> qa: u8=> qaW: *;
         v: -1, !RU;
     );
-    check!(i64, u16; uident; qv: u16; qa: u16; qaW: *;
+    check!(i64, u16=> uident; qv: u16=> qa: u16=> qaW: *;
         v: -1, !RU;
     );
-    check!(i64, u32; uident; qv: u32; qa: u32; qaW: *;
+    check!(i64, u32=> uident; qv: u32=> qa: u32=> qaW: *;
         v: -1, !RU;
     );
-    check!(i64, u64; uident; qv: +; qa: +; qaW: *;
+    check!(i64, u64=> uident; qv: +; qa: +; qaW: *;
         v: -1, !Uf;
     );
     for_bitness! {
         32 {
-            check!(i64, isize; sident; qv: isize; qa: isize; qaW: *;
+            check!(i64, isize=> sident; qv: isize=> qa: isize=> qaW: *;
                 v: -2_147_483_649, !RU; v: 2_147_483_648, !RO;
             );
-            check!(i64, usize; uident; qv: usize; qa: usize; qaW: *;
+            check!(i64, usize=> uident; qv: usize=> qa: usize=> qaW: *;
                 v: -1, !RU; v: 4_294_967_296, !RO;
             );
         }
@@ -136,66 +136,66 @@ fn test_i64() {
 
 #[test]
 fn test_u8() {
-    check!(u8, i8; uident; qv: +i8; qa: +i8; qaW: *;
+    check!(u8, i8=> uident; qv: +i8=> qa: +i8=> qaW: *;
         v: 127; v: 128, !Of;
     );
-    check!(u8, i16; uident; qv: *; qa: *; qaW: *);
-    check!(u8, i32; uident; qv: *; qa: *; qaW: *);
-    check!(u8, i64; uident; qv: *; qa: *; qaW: *);
-    check!(u8, u8; uident; qv: *; qa: *; qaW: *);
-    check!(u8, u16; uident; qv: *; qa: *; qaW: *);
-    check!(u8, u32; uident; qv: *; qa: *; qaW: *);
-    check!(u8, u64; uident; qv: *; qa: *; qaW: *);
-    check!(u8, isize; uident; qv: *; qa: *; qaW: *);
-    check!(u8, usize; uident; qv: *; qa: *; qaW: *);
+    check!(u8, i16=> uident; qv: *; qa: *; qaW: *);
+    check!(u8, i32=> uident; qv: *; qa: *; qaW: *);
+    check!(u8, i64=> uident; qv: *; qa: *; qaW: *);
+    check!(u8, u8=> uident; qv: *; qa: *; qaW: *);
+    check!(u8, u16=> uident; qv: *; qa: *; qaW: *);
+    check!(u8, u32=> uident; qv: *; qa: *; qaW: *);
+    check!(u8, u64=> uident; qv: *; qa: *; qaW: *);
+    check!(u8, isize=> uident; qv: *; qa: *; qaW: *);
+    check!(u8, usize=> uident; qv: *; qa: *; qaW: *);
 }
 
 #[test]
 fn test_u16() {
-    check!(u16, i8; uident; qv: +i8; qa: +i8; qaW: *;
+    check!(u16, i8=> uident; qv: +i8=> qa: +i8=> qaW: *;
         v: 128, !Of;
     );
-    check!(u16, i16; uident; qv: +i16; qa: +i16; qaW: *;
+    check!(u16, i16=> uident; qv: +i16=> qa: +i16=> qaW: *;
         v: 32_768, !Of;
     );
-    check!(u16, i32; uident; qv: *; qa: *; qaW: *);
-    check!(u16, i64; uident; qv: *; qa: *; qaW: *);
-    check!(u16, u8; uident; qv: u8; qa: u8; qaW: *;
+    check!(u16, i32=> uident; qv: *; qa: *; qaW: *);
+    check!(u16, i64=> uident; qv: *; qa: *; qaW: *);
+    check!(u16, u8=> uident; qv: u8=> qa: u8=> qaW: *;
         v: 256, !Of;
     );
-    check!(u16, u16; uident; qv: *; qa: *; qaW: *);
-    check!(u16, u32; uident; qv: *; qa: *; qaW: *);
-    check!(u16, u64; uident; qv: *; qa: *; qaW: *);
-    check!(u16, isize; uident; qv: *; qa: *; qaW: *);
-    check!(u16, usize; uident; qv: *; qa: *; qaW: *);
+    check!(u16, u16=> uident; qv: *; qa: *; qaW: *);
+    check!(u16, u32=> uident; qv: *; qa: *; qaW: *);
+    check!(u16, u64=> uident; qv: *; qa: *; qaW: *);
+    check!(u16, isize=> uident; qv: *; qa: *; qaW: *);
+    check!(u16, usize=> uident; qv: *; qa: *; qaW: *);
 }
 
 #[test]
 fn test_u32() {
-    check!(u32, i8; uident; qv: +i8; qa: +i8; qaW: *;
+    check!(u32, i8=> uident; qv: +i8=> qa: +i8=> qaW: *;
         v: 128, !Of;
     );
-    check!(u32, i16; uident; qv: +i16; qa: +i16; qaW: *;
+    check!(u32, i16=> uident; qv: +i16=> qa: +i16=> qaW: *;
         v: 32_768, !Of;
     );
-    check!(u32, i32; uident; qv: +i32; qa: +i32; qaW: *;
+    check!(u32, i32=> uident; qv: +i32=> qa: +i32=> qaW: *;
         v: 2_147_483_648, !Of;
     );
-    check!(u32, i64; uident; qv: *; qa: *; qaW: *);
-    check!(u32, u8; uident; qv: u8; qa: u8; qaW: *;
+    check!(u32, i64=> uident; qv: *; qa: *; qaW: *);
+    check!(u32, u8=> uident; qv: u8=> qa: u8=> qaW: *;
         v: 256, !Of;
     );
-    check!(u32, u16; uident; qv: u16; qa: u16; qaW: *;
+    check!(u32, u16=> uident; qv: u16=> qa: u16=> qaW: *;
         v: 65_536, !Of;
     );
-    check!(u32, u32; uident; qv: *; qa: *; qaW: *);
-    check!(u32, u64; uident; qv: *; qa: *; qaW: *);
+    check!(u32, u32=> uident; qv: *; qa: *; qaW: *);
+    check!(u32, u64=> uident; qv: *; qa: *; qaW: *);
     for_bitness! {
         32 {
-            check!(u32, isize; uident; qv: +isize; qa: +isize; qaW: *;
+            check!(u32, isize=> uident; qv: +isize=> qa: +isize=> qaW: *;
                 v: 2_147_483_647; v: 2_147_483_648, !Of;
             );
-            check!(u32, usize; uident; qv: *; qa: *; qaW: *);
+            check!(u32, usize=> uident; qv: *; qa: *; qaW: *);
         }
         64 {
             unimplemented!();
@@ -205,34 +205,34 @@ fn test_u32() {
 
 #[test]
 fn test_u64() {
-    check!(u64, i8; uident; qv: +i8; qa: +i8; qaW: *;
+    check!(u64, i8=> uident; qv: +i8=> qa: +i8=> qaW: *;
         v: 128, !Of;
     );
-    check!(u64, i16; uident; qv: +i16; qa: +i16; qaW: *;
+    check!(u64, i16=> uident; qv: +i16=> qa: +i16=> qaW: *;
         v: 32_768, !Of;
     );
-    check!(u64, i32; uident; qv: +i32; qa: +i32; qaW: *;
+    check!(u64, i32=> uident; qv: +i32=> qa: +i32=> qaW: *;
         v: 2_147_483_648, !Of;
     );
-    check!(u64, i64; uident; qv: +i64; qa: +i64; qaW: *;
+    check!(u64, i64=> uident; qv: +i64=> qa: +i64=> qaW: *;
         v: 9_223_372_036_854_775_808, !Of;
     );
-    check!(u64, u8; uident; qv: u8; qa: u8; qaW: *;
+    check!(u64, u8=> uident; qv: u8=> qa: u8=> qaW: *;
         v: 256, !Of;
     );
-    check!(u64, u16; uident; qv: u16; qa: u16; qaW: *;
+    check!(u64, u16=> uident; qv: u16=> qa: u16=> qaW: *;
         v: 65_536, !Of;
     );
-    check!(u64, u32; uident; qv: u32; qa: u32; qaW: *;
+    check!(u64, u32=> uident; qv: u32=> qa: u32=> qaW: *;
         v: 4_294_967_296, !Of;
     );
-    check!(u64, u64; uident; qv: *; qa: *; qaW: *);
+    check!(u64, u64=> uident; qv: *; qa: *; qaW: *);
     for_bitness! {
         32 {
-            check!(u64, isize; uident; qv: +isize; qa: +isize; qaW: *;
+            check!(u64, isize=> uident; qv: +isize=> qa: +isize=> qaW: *;
                 v: 2_147_483_648, !Of;
             );
-            check!(u64, usize; uident; qv: usize; qa: usize; qaW: *;
+            check!(u64, usize=> uident; qv: usize=> qa: usize=> qaW: *;
                 v: 4_294_967_296, !Of;
             );
         }
@@ -244,30 +244,30 @@ fn test_u64() {
 
 #[test]
 fn test_isize() {
-    check!(isize, i8; sident; qv: i8; qa: i8; qaW: *;
+    check!(isize, i8=> sident; qv: i8=> qa: i8=> qaW: *;
         v: -129, !RU; v: 128, !RO;
     );
-    check!(isize, i16; sident; qv: i16; qa: i16; qaW: *;
+    check!(isize, i16=> sident; qv: i16=> qa: i16=> qaW: *;
         v: -32_769, !RU; v: 32_768, !RO;
     );
-    check!(isize, u8; uident; qv: u8; qa: u8; qaW: *;
+    check!(isize, u8=> uident; qv: u8=> qa: u8=> qaW: *;
         v: -1, !RU; v: 256, !RO;
     );
-    check!(isize, u16; uident; qv: u16; qa: u16; qaW: *;
+    check!(isize, u16=> uident; qv: u16=> qa: u16=> qaW: *;
         v: -1, !RU; v: 65_536, !RO;
     );
-    check!(isize, isize; sident; qv: *; qa: *; qaW: *);
+    check!(isize, isize=> sident; qv: *; qa: *; qaW: *);
     for_bitness! {
         32 {
-            check!(isize, i32; sident; qv: *; qa: *; qaW: *);
-            check!(isize, i64; sident; qv: *; qa: *; qaW: *);
-            check!(isize, u32; uident; qv: +; qa: +; qaW: *;
+            check!(isize, i32=> sident; qv: *; qa: *; qaW: *);
+            check!(isize, i64=> sident; qv: *; qa: *; qaW: *);
+            check!(isize, u32=> uident; qv: +; qa: +; qaW: *;
                 v: -1, !Uf;
             );
-            check!(isize, u64; uident; qv: +; qa: +; qaW: *;
+            check!(isize, u64=> uident; qv: +; qa: +; qaW: *;
                 v: -1, !Uf;
             );
-            check!(isize, usize; uident; qv: +; qa: +; qaW: *;
+            check!(isize, usize=> uident; qv: +; qa: +; qaW: *;
                 v: -1, !Uf;
             );
         }
@@ -279,26 +279,26 @@ fn test_isize() {
 
 #[test]
 fn test_usize() {
-    check!(usize, i8; uident; qv: +i8; qa: +i8; qaW: *;
+    check!(usize, i8=> uident; qv: +i8=> qa: +i8=> qaW: *;
         v: 128, !Of;
     );
-    check!(usize, i16; uident; qv: +i16; qa: +i16; qaW: *;
+    check!(usize, i16=> uident; qv: +i16=> qa: +i16=> qaW: *;
         v: 32_768, !Of;
     );
-    check!(usize, u8; uident; qv: u8; qa: u8; qaW: *;
+    check!(usize, u8=> uident; qv: u8=> qa: u8=> qaW: *;
         v: 256, !Of;
     );
-    check!(usize, u16; uident; qv: u16; qa: u16; qaW: *;
+    check!(usize, u16=> uident; qv: u16=> qa: u16=> qaW: *;
         v: 65_536, !Of;
     );
-    check!(usize, usize; uident; qv: *; qa: *; qaW: *);
+    check!(usize, usize=> uident; qv: *; qa: *; qaW: *);
     for_bitness! {
         32 {
-            check!(usize, i32; uident; qv: +i32; qa: +i32; qaW: *);
-            check!(usize, i64; uident; qv: *; qa: *; qaW: *);
-            check!(usize, u32; uident; qv: *; qa: *; qaW: *);
-            check!(usize, u64; uident; qv: *; qa: *; qaW: *);
-            check!(usize, isize; uident; qv: +isize; qa: +isize; qaW: *);
+            check!(usize, i32=> uident; qv: +i32=> qa: +i32=> qaW: *);
+            check!(usize, i64=> uident; qv: *; qa: *; qaW: *);
+            check!(usize, u32=> uident; qv: *; qa: *; qaW: *);
+            check!(usize, u64=> uident; qv: *; qa: *; qaW: *);
+            check!(usize, isize=> uident; qv: +isize=> qa: +isize=> qaW: *);
         }
         64 {
             unimplemented!();
@@ -308,35 +308,35 @@ fn test_usize() {
 
 #[test]
 fn test_i_to_f() {
-    check!(i8,  f32; sident; qv: *; qa: *);
-    check!(i16, f32; sident; qv: *; qa: *);
-    check!(i32, f32; sident; qv: (+-16_777_216); qa: *;
+    check!(i8,  f32=> sident; qv: *; qa: *);
+    check!(i16, f32=> sident; qv: *; qa: *);
+    check!(i32, f32=> sident; qv: (+-16_777_216); qa: *;
         v: -16_777_217, !RU; v: 16_777_217, !RO;
     );
-    check!(i64, f32; sident; qv: (+-16_777_216); qa: *;
+    check!(i64, f32=> sident; qv: (+-16_777_216); qa: *;
         v: -16_777_217, !RU; v: 16_777_217, !RO;
     );
 
-    check!(u8,  f32; uident; qv: *; qa: *);
-    check!(u16, f32; uident; qv: *; qa: *);
-    check!(u32, f32; uident; qv: (, 16_777_216); qa: *;
+    check!(u8,  f32=> uident; qv: *; qa: *);
+    check!(u16, f32=> uident; qv: *; qa: *);
+    check!(u32, f32=> uident; qv: (, 16_777_216); qa: *;
         v: 16_777_217, !Of;
     );
-    check!(u64, f32; uident; qv: (, 16_777_216); qa: *;
+    check!(u64, f32=> uident; qv: (, 16_777_216); qa: *;
         v: 16_777_217, !Of;
     );
 
-    check!(i8,  f64; sident; qv: *; qa: *);
-    check!(i16, f64; sident; qv: *; qa: *);
-    check!(i32, f64; sident; qv: *; qa: *);
-    check!(i64, f64; sident; qv: (+-9_007_199_254_740_992); qa: *;
+    check!(i8,  f64=> sident; qv: *; qa: *);
+    check!(i16, f64=> sident; qv: *; qa: *);
+    check!(i32, f64=> sident; qv: *; qa: *);
+    check!(i64, f64=> sident; qv: (+-9_007_199_254_740_992); qa: *;
         v: -9_007_199_254_740_993, !RU; v: 9_007_199_254_740_993, !RO;
     );
 
-    check!(u8,  f64; uident; qv: *; qa: *);
-    check!(u16, f64; uident; qv: *; qa: *);
-    check!(u32, f64; uident; qv: *; qa: *);
-    check!(u64, f64; uident; qv: (, 9_007_199_254_740_992); qa: *;
+    check!(u8,  f64=> uident; qv: *; qa: *);
+    check!(u16, f64=> uident; qv: *; qa: *);
+    check!(u32, f64=> uident; qv: *; qa: *);
+    check!(u64, f64=> uident; qv: (, 9_007_199_254_740_992); qa: *;
         v: 9_007_199_254_740_993, !Of;
     );
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -3,67 +3,67 @@ macro_rules! as_expr {
 }
 
 macro_rules! check {
-    (@ $from:ty, $to:ty; $(;)*) => {};
+    (@ $from:ty, $to:ty=> $(;)*) => {};
 
-    (@ $from:ty, $to:ty; uident; $($tail:tt)*) => {
-        check!(@ $from, $to; v: 0;);
-        check!(@ $from, $to; v: 1;);
-        check!(@ $from, $to; $($tail)*);
+    (@ $from:ty, $to:ty=> uident; $($tail:tt)*) => {
+        check!(@ $from, $to=> v: 0;);
+        check!(@ $from, $to=> v: 1;);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; sident; $($tail:tt)*) => {
-        check!(@ $from, $to; v: -1;);
-        check!(@ $from, $to; v: 0;);
-        check!(@ $from, $to; v: 1;);
-        check!(@ $from, $to; $($tail)*);
+    (@ $from:ty, $to:ty=> sident; $($tail:tt)*) => {
+        check!(@ $from, $to=> v: -1;);
+        check!(@ $from, $to=> v: 0;);
+        check!(@ $from, $to=> v: 1;);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; fident; $($tail:tt)*) => {
-        check!(@ $from, $to; v: -1.0;);
-        check!(@ $from, $to; v:  0.0;);
-        check!(@ $from, $to; v:  1.0;);
-        check!(@ $from, $to; $($tail)*);
+    (@ $from:ty, $to:ty=> fident; $($tail:tt)*) => {
+        check!(@ $from, $to=> v: -1.0;);
+        check!(@ $from, $to=> v:  0.0;);
+        check!(@ $from, $to=> v:  1.0;);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; uidenta; $($tail:tt)*) => {
-        check!(@ $from, $to; a: 0.0;);
-        check!(@ $from, $to; a: 1.0;);
-        check!(@ $from, $to; $($tail)*);
+    (@ $from:ty, $to:ty=> uidenta; $($tail:tt)*) => {
+        check!(@ $from, $to=> a: 0.0;);
+        check!(@ $from, $to=> a: 1.0;);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; sidenta; $($tail:tt)*) => {
-        check!(@ $from, $to; a: -1.0;);
-        check!(@ $from, $to; a:  0.0;);
-        check!(@ $from, $to; a:  1.0;);
-        check!(@ $from, $to; $($tail)*);
+    (@ $from:ty, $to:ty=> sidenta; $($tail:tt)*) => {
+        check!(@ $from, $to=> a: -1.0;);
+        check!(@ $from, $to=> a:  0.0;);
+        check!(@ $from, $to=> a:  1.0;);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; fidenta; $($tail:tt)*) => {
-        check!(@ $from, $to; a: -1.0;);
-        check!(@ $from, $to; a:  0.0;);
-        check!(@ $from, $to; a:  1.0;);
-        check!(@ $from, $to; $($tail)*);
+    (@ $from:ty, $to:ty=> fidenta; $($tail:tt)*) => {
+        check!(@ $from, $to=> a: -1.0;);
+        check!(@ $from, $to=> a:  0.0;);
+        check!(@ $from, $to=> a:  1.0;);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; v: $src:expr, !$dst:expr; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> v: $src:expr, !$dst:expr; $($tail:tt)*) => {
         {
             let src: $from = $src;
             let dst: Result<$to, _> = src.value_into();
             assert_eq!(dst, Err($dst));
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; v: $src:expr; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> v: $src:expr; $($tail:tt)*) => {
         {
             let src: $from = $src;
             let dst: Result<$to, _> = src.value_into();
             assert_eq!(dst, Ok($src as $to));
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qv: *; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qv: *; $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -78,10 +78,10 @@ macro_rules! check {
                 Err(err) => panic!("qv {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qv: (+-$bound:expr); $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qv: (+-$bound:expr); $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -102,10 +102,10 @@ macro_rules! check {
                 Err(err) => panic!("qv {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qv: (, $bound:expr); $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qv: (, $bound:expr); $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -124,10 +124,10 @@ macro_rules! check {
                 Err(err) => panic!("qv {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qv: +; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qv: +; $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -146,10 +146,10 @@ macro_rules! check {
                 Err(err) => panic!("qv {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qv: +$max:ty; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qv: +$max:ty=> $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -168,10 +168,10 @@ macro_rules! check {
                 Err(err) => panic!("qv {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qv: $bound:ty; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qv: $bound:ty=> $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -192,10 +192,10 @@ macro_rules! check {
                 Err(err) => panic!("qv {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qv: $min:ty, $max:ty; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qv: $min:ty, $max:ty=> $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -216,28 +216,28 @@ macro_rules! check {
                 Err(err) => panic!("qv {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; a: $src:expr, !$dst:expr; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> a: $src:expr, !$dst:expr; $($tail:tt)*) => {
         {
             let src: $from = $src;
             let dst: Result<$to, _> = src.approx();
             assert_eq!(dst, Err($dst));
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; a: $src:expr; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> a: $src:expr; $($tail:tt)*) => {
         {
             let src: $from = $src;
             let dst: Result<$to, _> = src.approx();
             assert_eq!(dst, Ok($src as $to));
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qa: *; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qa: *; $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -252,10 +252,10 @@ macro_rules! check {
                 Err(err) => panic!("qa {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qa: +; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qa: +; $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -274,10 +274,10 @@ macro_rules! check {
                 Err(err) => panic!("qa {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qa: +$max:ty; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qa: +$max:ty=> $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -296,10 +296,10 @@ macro_rules! check {
                 Err(err) => panic!("qa {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qa: $bound:ty; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qa: $bound:ty=> $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -320,10 +320,10 @@ macro_rules! check {
                 Err(err) => panic!("qa {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    (@ $from:ty, $to:ty; qaW: *; $($tail:tt)*) => {
+    (@ $from:ty, $to:ty=> qaW: *; $($tail:tt)*) => {
         {
             extern crate quickcheck;
 
@@ -338,11 +338,11 @@ macro_rules! check {
                 Err(err) => panic!("qaW {:?}", err)
             }
         }
-        check!(@ $from, $to; $($tail)*);
+        check!(@ $from, $to=> $($tail)*);
     };
 
-    ($from:ty, $to:ty; $($tail:tt)*) => {
-        check! { @ $from, $to; $($tail)*; }
+    ($from:ty, $to:ty=> $($tail:tt)*) => {
+        check! { @ $from, $to=> $($tail)*; }
     };
 }
 


### PR DESCRIPTION
Stupid follow tokens. I changed `;` to `=>` everywhere. At least `ident tt*` is stable as of today!