### PR TITLE
Nightly 2015-11-30: Fix for non-exhaustive patterns when using empty structs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -573,8 +573,8 @@ where T: SignedInfinity, E: Into<RangeErrorKind> {
         use self::RangeErrorKind::*;
         match self.map_err(Into::into) {
             Ok(v) => v,
-            Err(NegOverflow(..)) => T::neg_infinity(),
-            Err(PosOverflow(..)) => T::pos_infinity(),
+            Err(NegOverflow) => T::neg_infinity(),
+            Err(PosOverflow) => T::pos_infinity(),
         }
     }
 }
@@ -599,8 +599,8 @@ where T: Saturated, E: Into<RangeErrorKind> {
         use self::RangeErrorKind::*;
         match self.map_err(Into::into) {
             Ok(v) => v,
-            Err(NegOverflow(..)) => T::saturated_min(),
-            Err(PosOverflow(..)) => T::saturated_max(),
+            Err(NegOverflow) => T::saturated_min(),
+            Err(PosOverflow) => T::saturated_max(),
         }
     }
 }


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/29383 for the breaking change.