### PR TITLE
Fix release/docs/repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ In addition, `From`/`Into` provide no facility for a conversion failing, meaning
 
 **Links**
 
-* [Latest Release](https://crates.io/crates/scan-rules/)
-* [Latest Docs](https://danielkeep.github.io/rust-scan-rules/doc/scan_rules/index.html)
-* [Repository](https://github.com/DanielKeep/rust-scan-rules)
+* [Latest Release](https://crates.io/crates/conv/)
+* [Latest Docs](https://danielkeep.github.io/rust-conv/doc/conv/index.html)
+* [Repository](https://github.com/DanielKeep/rust-conv)
 
 ## Compatibility
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@ In addition, `From`/`Into` requires all conversions to succeed or panic.  All co
 
 **Links**
 
-* [Latest Release](https://crates.io/crates/scan-rules/)
-* [Latest Docs](https://danielkeep.github.io/rust-scan-rules/doc/scan_rules/index.html)
-* [Repository](https://github.com/DanielKeep/rust-scan-rules)
+* [Latest Release](https://crates.io/crates/conv/)
+* [Latest Docs](https://danielkeep.github.io/rust-conv/doc/conv/index.html)
+* [Repository](https://github.com/DanielKeep/rust-conv)
 
 <span></span></div>
 


### PR DESCRIPTION
The links currently point to `scan-rules` instead of `conv`.