### PR TITLE
Use fully specified name for `std::result::Result` type.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -82,7 +82,7 @@ macro_rules! TryFrom {
     ) => {
         impl $crate::TryFrom<$prim> for $name {
             type Err = $crate::errors::Unrepresentable<$prim>;
-            fn try_from(src: $prim) -> Result<$name, Self::Err> {
+            fn try_from(src: $prim) -> ::std::result::Result<$name, Self::Err> {
                 $(
                     if src == $name::$var_names as $prim {
                         return Ok($name::$var_names);


### PR DESCRIPTION
This prevents name conflicts when the `std::result::Result` has been shadowed by another `Result` type.

Let me know if I should do any house keeping like a version bump or change log entry.